### PR TITLE
feat: add support for parsing mentions

### DIFF
--- a/_extensions/github/github.lua
+++ b/_extensions/github/github.lua
@@ -123,7 +123,7 @@ end
 function mentions(elem)
   local uri = nil
   local text = nil
-  if not citeproc and elem.text:match("^@(%w+)$") then
+  if elem.text:match("^@(%w+)$") then
     local mention = elem.text:match("^@(%w+)$")
     uri = "https://github.com/" .. mention
     text = pandoc.utils.stringify(elem.text)

--- a/_extensions/github/github.lua
+++ b/_extensions/github/github.lua
@@ -120,6 +120,18 @@ function commits(elem)
   return uri, text
 end
 
+function mentions(elem)
+  local uri = nil
+  local text = nil
+  if not citeproc and elem.text:match("^@(%w+)$") then
+    local mention = elem.text:match("^@(%w+)$")
+    uri = "https://github.com/" .. mention
+    text = pandoc.utils.stringify(elem.text)
+  end
+
+  return uri, text
+end
+
 function github(elem)
   uri, text = issues(elem)
   if not is_empty(uri) and not is_empty(text) then
@@ -127,6 +139,11 @@ function github(elem)
   end
 
   uri, text = commits(elem)
+  if not is_empty(uri) and not is_empty(text) then
+    return pandoc.Link(text, uri)
+  end
+
+  uri, text = mentions(elem)
   if not is_empty(uri) and not is_empty(text) then
     return pandoc.Link(text, uri)
   end

--- a/_extensions/github/github.lua
+++ b/_extensions/github/github.lua
@@ -26,6 +26,12 @@ local function is_empty(s)
   return s == nil or s == ''
 end
 
+local function github_uri(text, uri)
+  if not is_empty(uri) and not is_empty(text) then
+    return pandoc.Link(text, uri)
+  end
+end
+
 local github_repository = nil
 
 function get_repository(meta)
@@ -75,7 +81,7 @@ function issues(elem)
     end
   end
 
-  return uri, text
+  return github_uri(text, uri)
 end
 
 function commits(elem)
@@ -117,7 +123,7 @@ function commits(elem)
     end
   end
 
-  return uri, text
+  return github_uri(text, uri)
 end
 
 function mentions(elem)
@@ -129,23 +135,27 @@ function mentions(elem)
     text = pandoc.utils.stringify(elem.text)
   end
 
-  return uri, text
+  return github_uri(text, uri)
 end
 
 function github(elem)
-  uri, text = issues(elem)
-  if not is_empty(uri) and not is_empty(text) then
-    return pandoc.Link(text, uri)
+  local link = nil
+  if is_empty(link) then
+    link = issues(elem)
   end
-
-  uri, text = commits(elem)
-  if not is_empty(uri) and not is_empty(text) then
-    return pandoc.Link(text, uri)
+  
+  if is_empty(link) then
+    link = commits(elem)
   end
+  
+  -- if is_empty(link) then
+  --   link = mentions(elem)
+  -- end
 
-  uri, text = mentions(elem)
-  if not is_empty(uri) and not is_empty(text) then
-    return pandoc.Link(text, uri)
+  if is_empty(link) then
+    return elem
+  else
+    return link
   end
 end
 


### PR DESCRIPTION
This pull request adds support for parsing mentions. Now, when a mention is detected in the text, it will be converted into a link to the corresponding GitHub user/organisation profile.